### PR TITLE
bump github.com/hashicorp/go-getter from v1.5.11 to v2.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-errors/errors v1.1.1 // indirect
 	github.com/gruntwork-io/terragrunt v0.36.6
-	github.com/hashicorp/go-getter v1.5.11
+	github.com/hashicorp/go-getter v2.1.0
 	github.com/hashicorp/hcl/v2 v2.11.1
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20210625153042-09f34846faab
 	github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c // indirect


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- _[none]_

## Description

TODO

## Security Implications

- _[none]_

## System Availability

- _[none]_
